### PR TITLE
Added check_server_presence config option

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -32,6 +32,9 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('port')
                     ->defaultValue(35729)
                 ->end()
+                ->booleanNode('check_server_presence')
+                    ->defaultTrue()
+                ->end()
             ->end()
         ;
 

--- a/EventListener/ScriptInjectorListener.php
+++ b/EventListener/ScriptInjectorListener.php
@@ -13,12 +13,14 @@ class ScriptInjectorListener implements EventSubscriberInterface {
     protected $enabled;
     protected $host;
     protected $port;
+    protected $check_server_presence;
 
-    public function __construct($host = 'localhost', $port = 35729, $enabled = true)
+    public function __construct($host = 'localhost', $port = 35729, $enabled = true, $check_server_presence = true)
     {
         $this->host = $host;
         $this->port = $port;
         $this->enabled = $enabled;
+        $this->check_server_presence = $check_server_presence;
     }
 
     public function onKernelResponse(FilterResponseEvent $event)
@@ -68,9 +70,11 @@ class ScriptInjectorListener implements EventSubscriberInterface {
         if (false !== $pos) {
             $script = "http://$this->host:$this->port/livereload.js";
 
-            $headers = @get_headers($script);
-            if (!is_array($headers) || strpos($headers[0], '200') === false) {
-                return;
+            if ($this->check_server_presence) {
+                $headers = @get_headers($script);
+                if (!is_array($headers) || strpos($headers[0], '200') === false) {
+                    return;
+                }
             }
 
             $content = $substrFunction($content, 0, $pos)."\n<script src=\"$script\"></script>\n".$substrFunction($content, $pos);

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -5,7 +5,7 @@ parameters:
 services:
     kunstmaan_live_reload.script_injector:
         class: "%kunstmaan_live_reload.script_injector.class%"
-        arguments: ["%kunstmaan_live_reload.host%", "%kunstmaan_live_reload.port%", "%kunstmaan_live_reload.enabled%"]
+        arguments: ["%kunstmaan_live_reload.host%", "%kunstmaan_live_reload.port%", "%kunstmaan_live_reload.enabled%", "%kunstmaan_live_reload.check_server_presence%"]
         tags:
             - { name: kernel.event_subscriber }
 


### PR DESCRIPTION
As per issue #5, this provides an option to disable the get_headers() method from being called to check if the LiveReload server is present.
